### PR TITLE
Replace script block with match

### DIFF
--- a/cerbos-bin/policy/derived_roles_1.yml
+++ b/cerbos-bin/policy/derived_roles_1.yml
@@ -12,8 +12,8 @@ derived_roles:
     - name: employee_that_owns_the_record
       parentRoles: ["employee"]
       condition:
-        script: |-
-          input.resource.attr.owner == input.principal.id
+        match:
+          expr: request.resource.attr.owner == request.principal.id
 
     - name: any_employee
       parentRoles: ["employee"]

--- a/cerbos-bin/start.sh
+++ b/cerbos-bin/start.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTAINER_IMG=${CONTAINER_IMG:-"pkg.cerbos.dev/containers/cerbos"}
-CONTAINER_TAG=${CONTAINER_TAG:-"0.0.1"}
+CONTAINER_TAG=${CONTAINER_TAG:-"0.0.2-alpha.1"}
 
 docker run -i -t -p 3592:3592 \
   -v ${SCRIPT_DIR}/policy:/policies \


### PR DESCRIPTION
The `script` condition  block is for advanced uses and might even get deprecated in the future. Keeping it in the demo policy could confuse users.